### PR TITLE
chore(travis): run pretest instead of test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ node_js:
   - "6"
 
 script:
-  - npm test
+  - npm run pretest
   - npm run coveralls


### PR DESCRIPTION
Running 'npm run coveralls' is automatically going to run our tests.